### PR TITLE
wine cards now display distance and inventory count

### DIFF
--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -6,7 +6,7 @@ class RecommendationsController < ApplicationController
 
   def index
     if params[:color].present?
-      @top_five = Wine
+      top_five_wines = Wine
         .includes(:foods)
         .joins(food_pairings: :food)
         .where(foods: { id: params[:food_id] })
@@ -16,14 +16,20 @@ class RecommendationsController < ApplicationController
         .order(rating: :desc)
         .limit(5)
 
-      @top_five.each { |wine| create_inventories(wine) }
+      # passing the top five inventories to the index page
+      @top_five = top_five_wines.map do |wine|
+        create_inventories(wine)
+      end
+
     else
       @top_five = Wine.all
     end
   end
 
-
   def map
+    # Page should use inventory instance as it stores all the required information
+    # @inventory = Inventory.find(params[:id])
+
     @wine = Wine.find(params[:id])
     @markers = @wine.inventories.map do |wine|
       {
@@ -42,10 +48,12 @@ class RecommendationsController < ApplicationController
         longitude: avail["longitude"],
         latitude: avail["latitude"],
         name_saq: avail["name"],
-        address: avail["address1"]
+        address: avail["address1"],
+        distance: avail["distance"]
       )
       i.wine = wine
       i.save
+      return i
     end
   end
 

--- a/app/views/recommendations/index.html.erb
+++ b/app/views/recommendations/index.html.erb
@@ -15,7 +15,7 @@
 
 <%# wine cards %>
 <div class='d-flex flex-column wine-cards' >
-  <% @top_five.each do |wine| %>
-    <%= render 'shared/wine_card', wine: wine%>
+  <% @top_five.each do |inventory| %>
+    <%= render 'shared/wine_card', inventory: inventory%>
   <% end %>
 </div>

--- a/app/views/shared/_wine_card.html.erb
+++ b/app/views/shared/_wine_card.html.erb
@@ -1,7 +1,6 @@
 <%# Temporary grape variety and alcohol level values %>
-<% wine.grapes = 'some fancy schmancy grapes' %>
-<% wine.alcohol = 14 %>
-<% wine.origin = 'France, Sud-Ouest, Pyrénées/Gascogne' %>
+<% inventory.wine.grapes = 'some fancy schmancy grapes' %>
+<% inventory.wine.alcohol = 14 %>
 
-<%= render 'shared/wine_card_small', wine: wine %>
-<%= render 'shared/wine_card_large', wine: wine %>
+<%= render 'shared/wine_card_small', inventory: inventory %>
+<%= render 'shared/wine_card_large', inventory: inventory %>

--- a/app/views/shared/_wine_card_large.html.erb
+++ b/app/views/shared/_wine_card_large.html.erb
@@ -1,12 +1,12 @@
 <div class='wine-card wine-card-large disabled-card flex-column'>
   <%# title %>
   <div class='title-box d-flex justify-content-center align-items-center' style='width:100%'>
-    <p><%= wine.name %></p>
+    <p><%= inventory.wine.name %></p>
   </div>
 
   <%# image %>
   <div class='img-box d-flex justify-content-center align-items-center'>
-    <img src=<%= wine.image_url %>  alt="bottle image" >
+    <img src=<%= inventory.wine.image_url %>  alt="bottle image" >
   </div>
 
   <%# attributes %>
@@ -15,10 +15,10 @@
     <div class='d-flex flex-row' style='width:100%; padding-right:8px;'>
       <%# Price %>
       <div class='price-box d-flex justify-content-center align-items-center'>
-        <p><%= humanized_money_with_symbol(wine.price) %></p>
+        <p><%= humanized_money_with_symbol(inventory.wine.price) %></p>
       </div>
       <%# rating %>
-      <%= render 'shared/wine_card_rating', wine_rating: wine.rating, alignment: 'justify-content-end' %>
+      <%= render 'shared/wine_card_rating', wine_rating: inventory.wine.rating, alignment: 'justify-content-end' %>
     </div>
 
     <%# Information %>
@@ -26,36 +26,36 @@
       <%# color %>
       <div class='d-flex flex-row'>
         <p class='tag'>Color:</p>
-        <p class='content'><%= wine.color %></p>
+        <p class='content'><%= inventory.wine.color %></p>
       </div>
 
       <%# Region %>
       <div class='d-flex flex-row'>
         <p class='tag'>Origin:</p>
-        <p class='content'><%= wine.origin %></p>
+        <p class='content'><%= inventory.wine.origin %></p>
       </div>
 
       <%# Grape variety %>
       <div class='d-flex flex-row'>
         <p class='tag'>Grapes:</p>
-        <p class='content'><%= wine.grapes %></p>
+        <p class='content'><%= inventory.wine.grapes %></p>
       </div>
 
       <%# Alcohol level %>
       <div class='d-flex flex-row'>
         <p class='tag'>Alcohol level:</p>
-        <p class='content'><%= "#{wine.alcohol}%" %></p>
+        <p class='content'><%= "#{inventory.wine.alcohol}%" %></p>
       </div>
 
       <div class='d-flex flex-row justify-content-between'>
-        <p class='tag'>x units in stock</p> <%# Needs proper variable %>
-        <p class='tag'>y km distance</p>  <%# Needs proper variable %>
+        <p class='tag'><%= "#{inventory.bottle_count} #{inventory.bottle_count > 1 ? 'bottles' : 'bottle' } in stock" %></p>
+        <p class='tag'><%= "#{inventory.distance.delete(' ')} from you" %></p>
       </div>
     </div>
 
     <%# Find bottle CTA %>
     <div class='find-box d-flex align-items-center justify-content-center'>
-      <%= link_to('Find bottle', map_path(wine), class: 'btn') %>
+      <%= link_to('Find bottle', map_path(inventory), class: 'btn') %>
     </div>
 
   </div>

--- a/app/views/shared/_wine_card_small.html.erb
+++ b/app/views/shared/_wine_card_small.html.erb
@@ -1,7 +1,7 @@
 <div class='wine-card wine-card-small active-card flex-row '>
   <%# Image %>
   <div class='img-box d-flex justify-content-center align-items-center'>
-    <img src=<%= wine.image_url %>  alt="bottle image" >
+    <img src=<%= inventory.wine.image_url %>  alt="bottle image" >
   </div>
 
   <%# Attributes %>
@@ -9,7 +9,7 @@
 
     <%# title %>
     <div class='title-box d-flex justify-content-center align-items-center' style='width:100%'>
-      <p><%= wine.name %></p>
+      <p><%= inventory.wine.name %></p>
     </div>
 
     <%# Information %>
@@ -17,13 +17,13 @@
       <%# color %>
       <div class='d-flex flex-row'>
         <p class='tag'>Color:</p>
-        <p class='content'><%= wine.color %></p>
+        <p class='content'><%= inventory.wine.color %></p>
       </div>
 
       <%# Region %>
       <div class='d-flex flex-row'>
         <p class='tag'>Origin:</p>
-        <p class='content'><%= wine.origin %></p>
+        <p class='content'><%= inventory.wine.origin %></p>
       </div>
     </div>
 
@@ -31,10 +31,10 @@
     <div class='d-flex flex-row' style='width:100%;'>
       <%# Price %>
       <div class='price-box d-flex justify-content-center align-items-center'>
-        <p><%= humanized_money_with_symbol(wine.price) %></p>
+        <p><%= humanized_money_with_symbol(inventory.wine.price) %></p>
       </div>
       <%# rating %>
-      <%= render 'shared/wine_card_rating', wine_rating: wine.rating, alignment: 'justify-content-center' %>
+      <%= render 'shared/wine_card_rating', wine_rating: inventory.wine.rating, alignment: 'justify-content-center' %>
     </div>
   </div>
 </div>

--- a/db/migrate/20211130164409_add_distance_to_inventories.rb
+++ b/db/migrate/20211130164409_add_distance_to_inventories.rb
@@ -1,0 +1,5 @@
+class AddDistanceToInventories < ActiveRecord::Migration[6.0]
+  def change
+    add_column :inventories, :distance, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_29_213825) do
+ActiveRecord::Schema.define(version: 2021_11_30_164409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2021_11_29_213825) do
     t.float "longitude"
     t.string "name_saq"
     t.string "address"
+    t.string "distance"
     t.index ["wine_id"], name: "index_inventories_on_wine_id"
   end
 


### PR DESCRIPTION
Changelog:
Back-end:
- recommendation controller index method now passes inventory instances instead of wine instances (these being contained in inventory).
- added inventory variable to map method as it contains all the info needed for the map page.
- added distance to inventory table (migration)
- index page now passes inventory instance to map instead of wine instance.

Front-end:
- now displays actual origin, distance and bottle count on large cards.

![image](https://user-images.githubusercontent.com/55164748/144093781-462b6b66-319f-4b89-ae17-ed0a27ab3c67.png)

