### PR TITLE
fixed small card text overflow

### DIFF
--- a/app/assets/stylesheets/components/_wine_card.scss
+++ b/app/assets/stylesheets/components/_wine_card.scss
@@ -90,6 +90,16 @@
     }
   }
 
+  .origin-box {
+    width: 146.5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2; /* number of lines to show */
+            line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
   .price-box {
     width: 80px;
     height: 37px;

--- a/app/views/shared/_wine_card_small.html.erb
+++ b/app/views/shared/_wine_card_small.html.erb
@@ -23,7 +23,7 @@
       <%# Region %>
       <div class='d-flex flex-row'>
         <p class='tag'>Origin:</p>
-        <p class='content'><%= inventory.wine.origin %></p>
+        <p class='content origin-box'><%= inventory.wine.origin %></p>
       </div>
     </div>
 


### PR DESCRIPTION
Small cards no longer overflow because of overly long origin:
![image](https://user-images.githubusercontent.com/55164748/144135919-4da6fbb2-5c93-45e7-b145-3a66ef014916.png)
